### PR TITLE
fix: Fully qualify Result path in macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,12 +181,12 @@ pub fn derive_error(input: TokenStream) -> TokenStream {
         format!(
             r#"impl ::{std_crate}::fmt::Display for {name} {{
                 fn fmt(&self, f: &mut ::{std_crate}::fmt::Formatter<'_>) ->
-                    ::std::result::Result<(), ::{std_crate}::fmt::Error>
+                    ::{std_crate}::result::Result<(), ::{std_crate}::fmt::Error>
                 {{
                     match self {{
                         {display_matches}
                     }}
-                    ::std::result::Result::Ok(())
+                    ::{std_crate}::result::Result::Ok(())
                 }}
             }}"#
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,12 +181,12 @@ pub fn derive_error(input: TokenStream) -> TokenStream {
         format!(
             r#"impl ::{std_crate}::fmt::Display for {name} {{
                 fn fmt(&self, f: &mut ::{std_crate}::fmt::Formatter<'_>) ->
-                    Result<(), ::{std_crate}::fmt::Error>
+                    ::std::result::Result<(), ::{std_crate}::fmt::Error>
                 {{
                     match self {{
                         {display_matches}
                     }}
-                    Ok(())
+                    ::std::result::Result::Ok(())
                 }}
             }}"#
         )


### PR DESCRIPTION
I tend to name my top level crate errors as just bare `Error`, and also a typealias `Result` that's just the std `Result` with the error pre-specified, giving only one generic parameter.

Like so:
```rust
enum Error {
    Whatever,
}

type Result<T> = std::result::Result<T, Error>;
```

`onlyerror` produces some very mangled errors about missing generic parameters if you do this, since `Result` is not fully qualified in the generated code. If you have a `Result` type specified, it will resolve to that `Result`:
```
error: aborting due to previous error

For more information about this error, try `rustc --explain E0107`.
error[E0107]: type alias takes 1 generic argument but 2 generic arguments were supplied
  --> src\error.rs:11:10
   |
11 | #[derive(Error, Debug)]
   |          ^^^^^
   |          |
   |          expected 1 generic argument
   |          help: remove this generic argument
   |
note: type alias defined here, with 1 generic parameter: `T`
  --> src\error.rs:44:10
   |
44 | pub type Result<T> = std::result::Result<T, Error>;
   |          ^^^^^^ -
   = note: this error originates in the derive macro `Error` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR fully qualifies it to explicitly be the std `Result`. This fixes the problem in question and hardens against future name resolution errors.