### PR TITLE
Fix display impl for empty enum and non provided enum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
     strategy:
       matrix:
         rust:
+          - stable
           - beta
+          - 1.62.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
           - beta
-          - 1.62.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,31 @@
 version = 3
 
 [[package]]
+name = "basic-toml"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "error-iter"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8070547d90d1b98debb6626421d742c897942bbb78f047694a5eb769495eccd6"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "myn"
@@ -15,9 +36,140 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950af707b8005ae33bb0f0b20cb32b09750e7375085606dc45b2f2078a34e52"
 
 [[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
 name = "onlyerror"
 version = "0.1.2"
 dependencies = [
  "error-iter",
  "myn",
+ "trybuild",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "serde"
+version = "1.0.160"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.160"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501dbdbb99861e4ab6b60eb6a7493956a9defb644fd034bc4a5ef27c693c8a3a"
+dependencies = [
+ "basic-toml",
+ "glob",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ version = "0.1.2"
 dependencies = [
  "error-iter",
  "myn",
+ "rustversion",
  "trybuild",
 ]
 
@@ -67,6 +68,12 @@ checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,13 @@ std = []
 [lib]
 proc-macro = true
 
+[[test]]
+name = "compile_and_fail"
+path = "compile_tests/compiler.rs"
+
 [dependencies]
 myn = "0.1"
 
 [dev-dependencies]
 error-iter = "0.4"
+trybuild = "1.0.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ myn = "0.1"
 
 [dev-dependencies]
 error-iter = "0.4"
+rustversion = "1.0.12"
 trybuild = "1.0.80"

--- a/compile_tests/compiler.rs
+++ b/compile_tests/compiler.rs
@@ -9,5 +9,7 @@ fn compile_tests() {
     t.compile_fail("compile_tests/multiple_non_signed.rs");
     t.compile_fail("compile_tests/multiple_one_non_signed.rs");
     t.pass("compile_tests/no_display.rs");
-    t.compile_fail("compile_tests/no_display_no_impl.rs");
+    if rustversion::cfg!(since(1.68.0)) {
+        t.compile_fail("compile_tests/no_display_no_impl.rs");
+    }
 }

--- a/compile_tests/compiler.rs
+++ b/compile_tests/compiler.rs
@@ -1,0 +1,13 @@
+#[test]
+fn compile_tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("compile_tests/empty.rs");
+    t.pass("compile_tests/one_comment.rs");
+    t.pass("compile_tests/one_param.rs");
+    t.compile_fail("compile_tests/one_non_signed.rs");
+    t.pass("compile_tests/multiple_variant.rs");
+    t.compile_fail("compile_tests/multiple_non_signed.rs");
+    t.compile_fail("compile_tests/multiple_one_non_signed.rs");
+    t.pass("compile_tests/no_display.rs");
+    t.compile_fail("compile_tests/no_display_no_impl.rs");
+}

--- a/compile_tests/empty.rs
+++ b/compile_tests/empty.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, onlyerror::Error)]
+enum Error {}
+
+fn main() {}

--- a/compile_tests/multiple_non_signed.rs
+++ b/compile_tests/multiple_non_signed.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, onlyerror::Error)]
+enum Error {
+    First,
+    Second(usize),
+    Third { key: String, value: Vec<usize> },
+}
+
+fn main() {}

--- a/compile_tests/multiple_non_signed.stderr
+++ b/compile_tests/multiple_non_signed.stderr
@@ -1,0 +1,5 @@
+error: Required error message is missing
+ --> compile_tests/multiple_non_signed.rs:3:5
+  |
+3 |     First,
+  |     ^^^^^

--- a/compile_tests/multiple_one_non_signed.rs
+++ b/compile_tests/multiple_one_non_signed.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, onlyerror::Error)]
+enum Error {
+    /// First
+    First,
+    #[error("Second with {0}")]
+    Second(usize),
+    Third {
+        key: String,
+        value: Vec<usize>,
+    },
+}
+
+fn main() {}

--- a/compile_tests/multiple_one_non_signed.stderr
+++ b/compile_tests/multiple_one_non_signed.stderr
@@ -1,0 +1,5 @@
+error: Required error message is missing
+ --> compile_tests/multiple_one_non_signed.rs:7:5
+  |
+7 |     Third {
+  |     ^^^^^

--- a/compile_tests/multiple_variant.rs
+++ b/compile_tests/multiple_variant.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[derive(Debug, onlyerror::Error)]
 enum Error {
     /// First

--- a/compile_tests/multiple_variant.rs
+++ b/compile_tests/multiple_variant.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, onlyerror::Error)]
+enum Error {
+    /// First
+    First,
+    #[error("Second with {0}")]
+    Second(usize),
+    #[error("Third with {key} and {value:?}")]
+    Third { key: String, value: Vec<usize> },
+}
+
+fn main() {}

--- a/compile_tests/no_display.rs
+++ b/compile_tests/no_display.rs
@@ -1,0 +1,15 @@
+#[derive(Debug, onlyerror::Error)]
+#[no_display]
+enum Error {
+    First,
+    Second(usize),
+    Third { key: String, value: Vec<usize> },
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> {
+        write!(f, "Should work")
+    }
+}
+
+fn main() {}

--- a/compile_tests/no_display.rs
+++ b/compile_tests/no_display.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[derive(Debug, onlyerror::Error)]
 #[no_display]
 enum Error {

--- a/compile_tests/no_display_no_impl.rs
+++ b/compile_tests/no_display_no_impl.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[derive(Debug, onlyerror::Error)]
 #[no_display]
 enum Error {

--- a/compile_tests/no_display_no_impl.rs
+++ b/compile_tests/no_display_no_impl.rs
@@ -1,0 +1,12 @@
+#[derive(Debug, onlyerror::Error)]
+#[no_display]
+enum Error {
+    /// First
+    First,
+    #[error("Second with {0}")]
+    Second(usize),
+    #[error("Third with {key} and {value:?}")]
+    Third { key: String, value: Vec<usize> },
+}
+
+fn main() {}

--- a/compile_tests/no_display_no_impl.stderr
+++ b/compile_tests/no_display_no_impl.stderr
@@ -7,4 +7,5 @@ error[E0277]: `Error` doesn't implement `std::fmt::Display`
   = help: the trait `std::fmt::Display` is not implemented for `Error`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `std::error::Error`
+ --> $RUST/core/src/error.rs
   = note: this error originates in the derive macro `onlyerror::Error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/compile_tests/no_display_no_impl.stderr
+++ b/compile_tests/no_display_no_impl.stderr
@@ -1,0 +1,11 @@
+error[E0277]: `Error` doesn't implement `std::fmt::Display`
+ --> compile_tests/no_display_no_impl.rs:1:17
+  |
+1 | #[derive(Debug, onlyerror::Error)]
+  |                 ^^^^^^^^^^^^^^^^ `Error` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `Error`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `std::error::Error`
+ --> $RUST/core/src/error.rs
+  = note: this error originates in the derive macro `onlyerror::Error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/compile_tests/no_display_no_impl.stderr
+++ b/compile_tests/no_display_no_impl.stderr
@@ -1,11 +1,10 @@
 error[E0277]: `Error` doesn't implement `std::fmt::Display`
- --> compile_tests/no_display_no_impl.rs:1:17
+ --> compile_tests/no_display_no_impl.rs:3:17
   |
-1 | #[derive(Debug, onlyerror::Error)]
+3 | #[derive(Debug, onlyerror::Error)]
   |                 ^^^^^^^^^^^^^^^^ `Error` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `Error`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `std::error::Error`
- --> $RUST/core/src/error.rs
   = note: this error originates in the derive macro `onlyerror::Error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/compile_tests/one_comment.rs
+++ b/compile_tests/one_comment.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, onlyerror::Error)]
+enum Error {
+	/// One
+	One,
+}
+
+fn main() {}
+

--- a/compile_tests/one_comment.rs
+++ b/compile_tests/one_comment.rs
@@ -1,8 +1,9 @@
+#![allow(dead_code)]
+
 #[derive(Debug, onlyerror::Error)]
 enum Error {
-	/// One
-	One,
+    /// One
+    One,
 }
 
 fn main() {}
-

--- a/compile_tests/one_non_signed.rs
+++ b/compile_tests/one_non_signed.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyerror::Error)]
+enum Error {
+    One,
+}
+
+fn main() {}

--- a/compile_tests/one_non_signed.stderr
+++ b/compile_tests/one_non_signed.stderr
@@ -1,0 +1,5 @@
+error: Required error message is missing
+ --> compile_tests/one_non_signed.rs:3:5
+  |
+3 |     One,
+  |     ^^^

--- a/compile_tests/one_param.rs
+++ b/compile_tests/one_param.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[derive(Debug, onlyerror::Error)]
 enum Error {
     #[error("One")]

--- a/compile_tests/one_param.rs
+++ b/compile_tests/one_param.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyerror::Error)]
+enum Error {
+    #[error("One")]
+    One,
+}
+
+fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,8 @@
 //!
 //! - Only `enum` types are supported by the [`Error`] macro.
 //! - Only inline string interpolations are supported by the derived `Display` impl.
-//! - Either all variants must be given an error message, or none.
-//!   - In the latter case, you must hand-implement `Display`. This is a constraint required by the
-//!     `Error` trait.
+//! - Either all variants must be given an error message, or `#[no_display]` attribute must be set
+//!   to enum with hand-written `Display` implementation
 //! - `From` impls are only derived for `#[from]` and `#[source]` attributes, not implicitly for any
 //!   field names.
 //! - `Backtrace` is not supported.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ use std::{rc::Rc, str::FromStr as _};
 mod parser;
 
 #[allow(clippy::too_many_lines)]
-#[proc_macro_derive(Error, attributes(error, from, source))]
+#[proc_macro_derive(Error, attributes(error, from, source, no_display))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let ast = match Error::parse(input) {
         Ok(ast) => ast,
@@ -127,10 +127,11 @@ pub fn derive_error(input: TokenStream) -> TokenStream {
             ErrorSource::None => None,
         })
         .collect::<String>();
-    let display = ast
-        .variants
-        .iter()
-        .map(|v| {
+
+    let display_impl = if ast.no_display {
+        String::new()
+    } else {
+        let display = ast.variants.iter().map(|v| {
             let name = &v.name;
             let display = &v.display;
 
@@ -165,10 +166,7 @@ pub fn derive_error(input: TokenStream) -> TokenStream {
                     )
                 }
             })
-        })
-        .collect::<Vec<_>>();
-
-    let display_impl = {
+        });
         let mut display_matches = String::new();
         for res in display {
             match res {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -67,8 +67,7 @@ impl Error {
                 variants,
                 no_display: attributes
                     .into_iter()
-                    .find(|attr| attr.name.to_string() == "no_display")
-                    .is_some(),
+                    .any(|attr| attr.name.to_string() == "no_display"),
             }),
             tree => Err(spanned_error("Unexpected token", tree.as_span())),
         }
@@ -137,7 +136,7 @@ impl Variant {
             ty
         } else {
             // Skip everything before ','
-            while let Err(_) = input.expect_punct(',') {}
+            while input.expect_punct(',').is_err() {}
             VariantType::Unit
         };
 


### PR DESCRIPTION
If `onlyerror::Error` is derived to an empty enum or enum with no `#[error]` macros and no doc comments on its variants the compile error is unclear:
```
1 | #[derive(Debug, onlyerror::Error)]
  |                 ^^^^^^^^^^^^^^^^ `Error` cannot be formatted with the default formatter
```
It happens because `core::error::Error` (and `std::error::Error`) trait requires `Display` to be implemented.

Fixed by adding unreachable branch to match and removing checking for any `display` provided.

Now, this code compiles:
```rust
#[derive(Debug, onlyerror::Error)]
enum Error {}
```

And this code:
```rust
#[derive(Debug, onlyerror::Error)]
enum Error {
    Some,
    Other,
}
```
produces error:
```
error: Required error message is missing
 --> src/main.rs:3:5
  |
3 |     Some,
  |
```