### PR TITLE
Safe codegen

### DIFF
--- a/compile_tests/compiler.rs
+++ b/compile_tests/compiler.rs
@@ -9,7 +9,7 @@ fn compile_tests() {
     t.compile_fail("compile_tests/multiple_non_signed.rs");
     t.compile_fail("compile_tests/multiple_one_non_signed.rs");
     t.pass("compile_tests/no_display.rs");
-    if rustversion::cfg!(since(1.68.0)) {
+    if rustversion::cfg!(all(stable, since(1.68.0))) {
         t.compile_fail("compile_tests/no_display_no_impl.rs");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub fn derive_error(input: TokenStream) -> TokenStream {
                             if v.display_fields.contains(&Rc::from(format!("field_{i}"))) {
                                 format!("field_{i},")
                             } else {
-                                "_,".to_string()
+                                String::from("_,")
                             }
                         })
                         .collect::<String>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,18 +175,18 @@ pub fn derive_error(input: TokenStream) -> TokenStream {
                 Ok(msg) => display_matches.push_str(&msg),
             }
         }
-        display_matches.push_str(&format!(
-            "_ => unsafe {{ ::{std_crate}::hint::unreachable_unchecked()}}"
-        ));
+        let display_matches = if display_matches.is_empty() {
+            String::from("Ok(())")
+        } else {
+            format!("match self {{ {display_matches} }}")
+        };
 
         format!(
             r#"impl ::{std_crate}::fmt::Display for {name} {{
                 fn fmt(&self, f: &mut ::{std_crate}::fmt::Formatter<'_>) ->
                     ::{std_crate}::result::Result<(), ::{std_crate}::fmt::Error>
                 {{
-                    match self {{
-                        {display_matches}
-                    }}
+                    {display_matches}
                 }}
             }}"#
         )


### PR DESCRIPTION
The codegen was updated in #11 to handle empty enums by generating an empty match statement. The unsafe keyword is necessary for this construct to be accepted by the compiler. We can remove the unsafe keyword by conditionally generating the match statement.